### PR TITLE
feat: PT-18221 add message version to query response

### DIFF
--- a/src/Messages/QueryResponseVersionTwo.php
+++ b/src/Messages/QueryResponseVersionTwo.php
@@ -17,6 +17,7 @@ class QueryResponseVersionTwo extends QueryResponse
     private $authenticationValue;
     private $transStatusReason;
     private $enrolled;
+    private $messageVersion;
 
     public function __construct(array $data)
     {
@@ -30,6 +31,7 @@ class QueryResponseVersionTwo extends QueryResponse
         $this->authenticationValue = $data['authenticationValue'] ?? null;
         $this->transStatusReason = $data['transStatusReason'] ?? null;
         $this->enrolled = $data['enrolled'] ?? null;
+        $this->messageVersion = $data['messageVersion'] ?? null;
     }
 
     public function id()
@@ -120,12 +122,18 @@ class QueryResponseVersionTwo extends QueryResponse
         return true;
     }
 
+    public function messageVersion(): ?string
+    {
+        return $this->messageVersion;
+    }
+
     public function extra(): array
     {
         return [
             'transStatusReason' => $this->reasonCode(),
             'acsTransId' => $this->acsTransID(),
             'threeDSServerTransID' => $this->threeDSServerTransID(),
+            'messageVersion' => $this->messageVersion(),
         ];
     }
 
@@ -144,6 +152,7 @@ class QueryResponseVersionTwo extends QueryResponse
             'authenticationValue' => $result['authenticationValue'] ?? null,
             'transStatusReason' => $result['transStatusReason'] ?? null,
             'version' => self::readVersion($result['messageVersion'] ?? '2.1.0'),
+            'messageVersion' => $result['messageVersion'] ?? null,
         ];
 
         return new self($data);

--- a/tests/Functionality/QueryProcessTest.php
+++ b/tests/Functionality/QueryProcessTest.php
@@ -28,6 +28,8 @@ class QueryProcessTest extends BaseTestCase
         $this->assertEquals('05', $response->eci());
         $this->assertEquals('AAACCZJiUGVlF4U5AmJQEwAAAAA=', $response->cavv());
         $this->assertEquals('Z8UuHYF8Epz46M8V/MkGJDl2Y5E=', $response->xid());
+
+        $this->assertArrayNotHasKey('extra', $response->toArray());
     }
 
     public function testItDoesNotAuthenticateWhenResponseIsInvalid()
@@ -41,6 +43,8 @@ class QueryProcessTest extends BaseTestCase
         $this->assertEquals('06', $response->eci());
         $this->assertEquals('CAACAlRGNFVVBEYZGUY0EwAAAAA=', $response->cavv());
         $this->assertEquals('0CI2blBv4uSnIqelFXJX0mV+fMg=', $response->xid());
+
+        $this->assertArrayNotHasKey('extra', $response->toArray());
     }
 
     public function testItDoesNotFallForInvalidAuthentications()
@@ -54,6 +58,8 @@ class QueryProcessTest extends BaseTestCase
         $this->assertEquals('05', $response->eci());
         $this->assertEquals('AAACA1aTWUhYcxeGg5NZEAAAEAA=', $response->cavv());
         $this->assertEquals('UbRrlDARTXFT8GVALigF4MDyhkk=', $response->xid());
+
+        $this->assertArrayNotHasKey('extra', $response->toArray());
     }
 
     public function testItGetsAnArrayWithTheInformation()
@@ -72,6 +78,8 @@ class QueryProcessTest extends BaseTestCase
             'version' => MPI::VERSION_ONE,
             'id' => 1,
         ], $response->toArray());
+
+        $this->assertArrayNotHasKey('extra', $response->toArray());
     }
 
     public function testItObtainsQueryVersionTwoSuccessfully()
@@ -92,6 +100,13 @@ class QueryProcessTest extends BaseTestCase
         $this->assertTrue($response->isAuthenticated());
         $this->assertEquals('AAABBZEEBgAAAAAAAAQGAAAAAAA=', $response->cavv());
         $this->assertEquals('05', $response->eci());
+
+        $this->assertEquals([
+            'transStatusReason' => null,
+            'acsTransId' => '37a7b6e0-fd58-4e38-98de-79c70c526a47',
+            'threeDSServerTransID' => 'eadd3a60-b870-41d0-977f-921b3dbe6323/MkGJDl2Y5E=',
+            'messageVersion' => null,
+        ], $response->toArray()['extra']);
     }
 
     public function testItDoesAuthenticateOnTreeDSServer()
@@ -105,6 +120,13 @@ class QueryProcessTest extends BaseTestCase
         $this->assertEquals('Y', $response->toArray()['enrolled']);
         $this->assertFalse($response->isAuthenticated());
         $this->assertEquals('U', $response->authenticated());
+
+        $this->assertEquals([
+            'transStatusReason' => '22',
+            'acsTransId' => '155222d5-3933-475b-a153-db899eee38b2',
+            'threeDSServerTransID' => '515ba5ef-100e-4040-8028-df915f9fcdab',
+            'messageVersion' => null,
+        ], $response->toArray()['extra']);
     }
 
     public function testItHandlesTheNewQueryResponseOnV2()
@@ -118,6 +140,13 @@ class QueryProcessTest extends BaseTestCase
         $this->assertEquals('Y', $response->enrolled());
         $this->assertTrue($response->isAuthenticated());
         $this->assertEquals('Y', $response->authenticated());
+
+        $this->assertEquals([
+            'transStatusReason' => null,
+            'acsTransId' => '173f9515-41b3-4cfc-a9a4-5d8c839faad6',
+            'threeDSServerTransID' => '3ed1f41b-30bc-435b-90eb-40028a57d4ea',
+            'messageVersion' => '2.2.0',
+        ], $response->toArray()['extra']);
     }
 
     public function testItHandlesANonEnrolledInsteadOfError()
@@ -130,5 +159,12 @@ class QueryProcessTest extends BaseTestCase
         $response = $mpi->query(8);
         $this->assertEquals('N', $response->enrolled());
         $this->assertNull($response->authenticated());
+
+        $this->assertEquals([
+            'transStatusReason' => null,
+            'acsTransId' => null,
+            'threeDSServerTransID' => '6063ae4f-a3f2-466e-926c-f568b17ace44',
+            'messageVersion' => '2.1.0',
+        ], $response->toArray()['extra']);
     }
 }


### PR DESCRIPTION
Se añade campo `extra['messageVersion']` a la  respuesta `query` de la versión 2